### PR TITLE
dict object has no element Undefined

### DIFF
--- a/dirindex/_cli.py
+++ b/dirindex/_cli.py
@@ -131,9 +131,9 @@ def make(template, directory, dry, recursive, single, filename, pattern, hide):
         for root, dirs, files in os.walk(directory):
             dirs = pattern_filter(dirs, pattern, hide)
             files = pattern_filter(files, pattern, hide)
-            for d in dirs:
+            for d in sorted(dirs):
                 args["dir"].append(mkent(os.path.join(root, d), directory))
-            for f in files:
+            for f in sorted(files):
                 args["file"].append(mkent(os.path.join(root, f), directory))
         log.debug("output %s / %s arg=%s", directory, filename, args)
         if not dry:
@@ -148,9 +148,9 @@ def make(template, directory, dry, recursive, single, filename, pattern, hide):
             }
             dirs = pattern_filter(dirs, pattern, hide)
             files = pattern_filter(files, pattern, hide)
-            for d in dirs:
+            for d in sorted(dirs):
                 args["dir"].append(mkent(os.path.join(root, d), root))
-            for f in files:
+            for f in sorted(files):
                 args["file"].append(mkent(os.path.join(root, f), root))
             log.debug("output %s / %s args=%s", root, filename, args)
             if not dry:
@@ -160,7 +160,7 @@ def make(template, directory, dry, recursive, single, filename, pattern, hide):
         # single directory
         files = os.listdir(directory)
         files = pattern_filter(files, pattern, hide)
-        for f in files:
+        for f in sorted(files):
             ent = mkent(os.path.join(directory, f), directory)
             if stat.S_ISDIR(ent["stat"].st_mode):
                 args["dir"].append(ent)

--- a/dirindex/templates/apache
+++ b/dirindex/templates/apache
@@ -5,10 +5,10 @@
  </head>
  <body>
 <h1>Index of {{root}}</h1>
-<ul>{% for i in dir|sort(attribute=name) %}
+<ul>{% for i in dir %}
 <li><a href="{{i.name}}/"> {{i.name}}/</a></li>
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <li><a href="{{i.name}}"> {{i.name}}</a></li>
 {%- endfor %}
 </ul>

--- a/dirindex/templates/golang
+++ b/dirindex/templates/golang
@@ -1,8 +1,8 @@
 <pre>
-{% for i in dir|sort(attribute=name) %}
+{% for i in dir %}
 <a href="{{i.name}}/">{{i.name}}/</a>
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <a href="{{i.name}}">{{i.name}}</a>
 {%- endfor %}
 </pre>

--- a/dirindex/templates/lighttpd
+++ b/dirindex/templates/lighttpd
@@ -23,10 +23,10 @@ div.foot { font: 90% monospace; color: #787878; padding-top: 4px;}
 <table summary="Directory Listing" cellpadding="0" cellspacing="0">
 <thead><tr><th class="n">Name</th><th class="m">Last Modified</th><th class="s">Size</th><th class="t">Type</th></tr></thead>
 <tbody>
-{% for i in dir|sort(attribute=name) %}
+{% for i in dir %}
 <tr class="d"><td class="n"><a href="{{i.name}}/">{{i.name}}</a>/</td><td class="m">{{i.stat.st_mtime | strftime("%Y-%b-%d %H:%M:%S")}}</td><td class="s">- &nbsp;</td><td class="t">Directory</td></tr>
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <tr><td class="n"><a href="{{i.name}}">{{i.name}}</a></td><td class="m">{{i.stat.st_mtime | strftime("%Y-%b-%d %H:%M:%S")}}</td><td class="s">{{i.stat.st_size | filesizeformat}}</td><td class="t">{{i.content_type | default("application/octet-stream")}}</td></tr>
 {%- endfor %}
 </tbody>

--- a/dirindex/templates/ls-l
+++ b/dirindex/templates/ls-l
@@ -1,7 +1,7 @@
 total {{file|map(attribute="stat")|map(attribute="st_size")|sum}}
-{%- for i in dir|sort(attribute=name) %}
+{%- for i in dir %}
 {{i.stat.st_mode|filemode}} {{"%3d"|format(i.stat.st_nlink)}} {{"%5d"|format(i.stat.st_uid)}} {{"%5d"|format(i.stat.st_gid)}} {{"%9d"|format(i.stat.st_size)}}  {{i.stat.st_mtime|strftime("%v %H:%M")}} {{i.name}}/
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 {{i.stat.st_mode|filemode}} {{"%3d"|format(i.stat.st_nlink)}} {{"%5d"|format(i.stat.st_uid)}} {{"%5d"|format(i.stat.st_gid)}} {{"%9d"|format(i.stat.st_size)}}  {{i.stat.st_mtime|strftime("%v %H:%M")}} {{i.name}}
 {%- endfor %}

--- a/dirindex/templates/nginx
+++ b/dirindex/templates/nginx
@@ -2,10 +2,10 @@
 <head><title>Index of {{root}}</title></head>
 <body>
 <h1>Index of {{root}}</h1><hr><pre><a href="../">../</a>
-{%- for i in dir|sort(attribute=name) %}
+{%- for i in dir %}
 <a href="{{i.name}}/">{{"%-55s"|format(i.name+"/</a>")}}{{i.stat.st_mtime | strftime("%d-%m-%Y %H:%M")}}{{"%20s"|format("-")}}
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <a href="{{i.name}}/">{{"%-55s"|format(i.name+"</a>")}}{{i.stat.st_mtime | strftime("%d-%m-%Y %H:%M")}}{{"%20d"| format(i.stat.st_size)}}
 {%- endfor %}
 </pre><hr></body>

--- a/dirindex/templates/nginx-noexact
+++ b/dirindex/templates/nginx-noexact
@@ -2,10 +2,10 @@
 <head><title>Index of {{root}}</title></head>
 <body>
 <h1>Index of {{root}}</h1><hr><pre><a href="../">../</a>
-{%- for i in dir|sort(attribute=name) %}
+{%- for i in dir %}
 <a href="{{i.name}}/">{{"%-55s"|format(i.name+"/</a>")}}{{i.stat.st_mtime | strftime("%d-%m-%Y %H:%M")}}{{"%20s"|format("-")}}
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <a href="{{i.name}}/">{{"%-55s"|format(i.name+"</a>")}}{{i.stat.st_mtime | strftime("%d-%m-%Y %H:%M")}}{{"%20s"|format(i.stat.st_size | filesizeformat)}}
 {%- endfor %}
 </pre><hr></body>

--- a/dirindex/templates/python
+++ b/dirindex/templates/python
@@ -7,10 +7,10 @@
 <body>
 <h1>Directory listing for {{root}}</h1>
 <hr>
-<ul>{% for i in dir|sort(attribute=name) %}
+<ul>{% for i in dir %}
 <li><a href="{{i.name}}/"> {{i.name}}/</a></li>
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 <li><a href="{{i.name}}"> {{i.name}}</a></li>
 {%- endfor %}
 </ul>

--- a/dirindex/templates/thttpd
+++ b/dirindex/templates/thttpd
@@ -14,10 +14,10 @@
     <pre>
 mode  links    bytes  last-changed  name
     <hr>
-{%- for i in dir|sort(attribute=name) %}
+{%- for i in dir %}
 {{i.stat.st_mode|filemode|truncate(4, True, '')}}{{"%4d"|format(i.stat.st_nlink)}}{{"%12d"|format(i.stat.st_size)}}  {{i.stat.st_mtime|strftime("%b %d %H:%M")}}  <a href="{{i.name}}/">{{i.name}}</a>/
 {%- endfor %}
-{%- for i in file|sort(attribute=name) %}
+{%- for i in file %}
 {{i.stat.st_mode|filemode|truncate(4, True, '')}}{{"%4d"|format(i.stat.st_nlink)}}{{"%12d"|format(i.stat.st_size)}}  {{i.stat.st_mtime|strftime("%b %d %H:%M")}}  <a href="{{i.name}}">{{i.name}}</a>
 {%- endfor %}
     </pre>

--- a/dirindex/templates/tomcat
+++ b/dirindex/templates/tomcat
@@ -8,7 +8,7 @@
 <td align="center"><font size="+1"><strong>Size</strong></font></td>
 <td align="right"><font size="+1"><strong>Last Modified</strong></font></td>
 </tr>
-{%- for i in dir|sort(attribute=name) -%}
+{%- for i in dir -%}
 {% if loop.index % 2 == 1 %}
 <tr bgcolor="#eeeeee">
 {% else %}
@@ -20,7 +20,7 @@
 <td align="right"><tt>{{i.stat.st_mtime | strftime("%a, %d %b %Y %H:%M:%S %z")}}</tt></td>
 </tr>
 {% endfor %}
-{%- for i in file|sort(attribute=name) -%}
+{%- for i in file -%}
 {% if loop.index % 2 == 1 %}
 <tr bgcolor="#eeeeee">
 {% else %}

--- a/dirindex/templates/webrick
+++ b/dirindex/templates/webrick
@@ -18,10 +18,10 @@
 <TH class="name">Name</TH><TH class="mtime">Last modified</TH><TH class="size">Size</TH>
 </TR></THEAD>
 <TBODY>
-{% for i in dir|sort(attribute=name) %}
+{% for i in dir %}
 <TR><TD class="name"><A HREF="{{i.name}}/">{{i.name}}/</A></TD><TD class="mtime">{{i.stat.st_mtime|strftime("%Y/%m/%d %H:%M")}}</TD><TD class="size">-</TD></TR>
 {% endfor %}
-{% for i in file|sort(attribute=name) %}
+{% for i in file %}
 <TR><TD class="name"><A HREF="{{i.name}}">{{i.name}}</A></TD><TD class="mtime">{{i.stat.st_mtime|strftime("%Y/%m/%d %H:%M")}}</TD><TD class="size">{{i.stat.st_size}}</TD></TR>
 {% endfor %}
 </TBODY></TABLE><HR>    <ADDRESS>


### PR DESCRIPTION
テンプレートでソートするようにしたら、エラーが。

github actionsのubuntu-latestにpip install dirindexで入れて`dirindex make --template apache --recursive .`すると出る？
手元の環境では出ない。環境によるのかも。

```
  File "<template>", line 11, in <module>
  File "/usr/lib/python3/dist-packages/jinja2/filters.py", line 283, in do_sort
    return sorted(value, key=key_func, reverse=reverse)
jinja2.exceptions.UndefinedError: dict object has no element Undefined
```

コード側でソートする？